### PR TITLE
fake proxy tests

### DIFF
--- a/condarc
+++ b/condarc
@@ -1,5 +1,9 @@
-offline: False
-show_channel_urls: True
-allow_other_channels: False
-default_channels:
-  - http://localhost:8000/quansight-small-test
+offline: false  #!final
+show_channel_urls: true
+allow_other_channels: False  #!final
+channels:  #!final
+  - http://localhost:8000/quansight-small-test  #!top
+default_channels:  #!final
+  - http://localhost:8000/quansight-small-test  #!top
+whitelist_channels:  #!final
+  - http://localhost:8000/quansight-small-test  #!top

--- a/create-mirror.sh
+++ b/create-mirror.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 # Creates local mirror of a conda channel
 
-display_usage() { 
+display_usage() {
     echo "Creates local mirror of a conda channel"
     echo
     echo "Usage: create-mirror.sh <channel> [flags]"
     echo "  channel: channel to be mirrored"
     echo "  flags: flags to pass to conda mirror"
-	} 
+	}
 
-if [[ $# == 0 || $1 == "--help" ||  $1 == "-h" ]] 
-then 
+if [[ $# == 0 || $1 == "--help" ||  $1 == "-h" ]]
+then
     display_usage
     exit 0
 fi
@@ -20,7 +20,7 @@ eval "$(conda shell.bash hook)"
 
 # create local mirror
 echo "creating conda env with conda-mirror installed"
-conda create -y -n mirror-env -c conda-forge conda-mirror
+conda create -y -n mirror-env -c conda-forge -c quansight conda-mirror
 conda activate mirror-env
 
 echo "creating local mirror of $1 channel (linux-64, noarch)..."

--- a/create-mirror.sh
+++ b/create-mirror.sh
@@ -24,6 +24,6 @@ conda create -y -n mirror-env -c quansight -c conda-forge conda-mirror
 conda activate mirror-env
 
 echo "creating local mirror of $1 channel (linux-64, noarch)..."
-conda mirror -vv --upstream-channel $1 --target-directory mirrors/$1 --platform linux-64 "${@:2}"
-conda mirror -vv --upstream-channel $1 --target-directory mirrors/$1 --platform noarch "${@:2}"
+conda mirror -vv --insecure --upstream-channel $1 --target-directory mirrors/$1 --platform linux-64 "${@:2}"
+conda mirror -vv --insecure --upstream-channel $1 --target-directory mirrors/$1 --platform noarch "${@:2}"
 conda deactivate

--- a/create-mirror.sh
+++ b/create-mirror.sh
@@ -20,7 +20,7 @@ eval "$(conda shell.bash hook)"
 
 # create local mirror
 echo "creating conda env with conda-mirror installed"
-conda create -y -n mirror-env -c conda-forge -c quansight conda-mirror
+conda create -y -n mirror-env -c quansight -c conda-forge conda-mirror
 conda activate mirror-env
 
 echo "creating local mirror of $1 channel (linux-64, noarch)..."

--- a/test_full_mirror.py
+++ b/test_full_mirror.py
@@ -70,27 +70,6 @@ def test_env_creation_http(setup_mirror_server, pkg_list):
     assert _clean_json(fmirror) == _clean_json(foffline)
 
 
-@pytest.mark.parametrize("pkg_list", [["python"], ["python", "conda"]])
-def test_env_creation_http_no_proxy(setup_mirror_server, pkg_list):
-    # add some bad proxy setting to make sure that we are really getting local
-    # packages only.
-    env_name = "_".join(pkg_list)
-    env = dict(os.environ)
-    env.update(PROXY_SETTINGS)
-
-    subprocess.run(
-        ["./create-env.sh", f"http://localhost:8000/{CHANNEL}", env_name, *pkg_list],
-        env=env
-    )
-
-    fweb = f"test-data/{env_name}-from-web.json"
-    fmirror = f"test-data/{env_name}-from-mirror.json"
-    foffline = f"test-data/{env_name}-from-mirror-offline.json"
-
-    assert _clean_json(fweb) == _clean_json(fmirror)
-    assert _clean_json(fmirror) == _clean_json(foffline)
-
-
 def check_only_offline(env, pkg_list):
     env_name = "_".join(pkg_list)
     print("-----------------------------------------------------------------")
@@ -99,7 +78,7 @@ def check_only_offline(env, pkg_list):
     p = subprocess.run(["conda", "config", "--show"], env=env)
     p.check_returncode()
     p = subprocess.run(
-        ["conda", "create", "-y", "-n", env_name + "-from-mirror-offline", *pkg_list],
+        ["conda", "create", "-y", "-n", env_name + "-from-mirror-offline", "--override-channels", "-c", "http://localhost:8000/quansight-small-test", *pkg_list],
         env=env,
     )
     p.check_returncode()

--- a/test_full_mirror.py
+++ b/test_full_mirror.py
@@ -9,6 +9,14 @@ import pytest
 
 
 CHANNEL = "quansight-small-test"
+PROXY_SETTINGS = {
+    "HTTP_PROXY": "http://fake.proxy.server/",
+    "HTTPS_PROXY": "https://fake.proxy.server/",
+    "NO_PROXY": "localhost,127.0.0.1,0.0.0.0",
+    "http_proxy": "http://fake.proxy.server/",
+    "https_proxy": "https://fake.proxy.server/",
+    "no_proxy": "localhost,127.0.0.1,0.0.0.0",
+}
 
 
 @pytest.fixture(scope="module")
@@ -62,11 +70,28 @@ def test_env_creation_http(setup_mirror_server, pkg_list):
 
 
 @pytest.mark.parametrize("pkg_list", [["python"], ["python", "conda"]])
-def test_env_creation_condarc(setup_mirror_server, pkg_list):
+def test_env_creation_http_no_proxy(setup_mirror_server, pkg_list):
+    # add some bad proxy setting to make sure that we are really getting local
+    # packages only.
     env_name = "_".join(pkg_list)
     env = dict(os.environ)
-    env["CONDARC"] = "./condarc"
+    env.update(PROXY_SETTINGS)
 
+    subprocess.run(
+        ["./create-env.sh", f"http://localhost:8000/{CHANNEL}", env_name, *pkg_list],
+        env=env
+    )
+
+    fweb = f"test-data/{env_name}-from-web.json"
+    fmirror = f"test-data/{env_name}-from-mirror.json"
+    foffline = f"test-data/{env_name}-from-mirror-offline.json"
+
+    assert _clean_json(fweb) == _clean_json(fmirror)
+    assert _clean_json(fmirror) == _clean_json(foffline)
+
+
+def check_only_offline(env, pkg_list):
+    env_name = "_".join(pkg_list)
     print("-----------------------------------------------------------------")
     print(f"Creating new envs from web and offline mirrors using packages: {pkg_list}")
     print("-----------------------------------------------------------------")
@@ -90,6 +115,21 @@ def test_env_creation_condarc(setup_mirror_server, pkg_list):
     data = _clean_json(foffline)
     pkg_names = {rec["name"] for rec in data}
     assert set(pkg_list) <= pkg_names
+
+
+@pytest.mark.parametrize("pkg_list", [["python"], ["python", "conda"]])
+def test_env_creation_condarc(setup_mirror_server, pkg_list):
+    env = dict(os.environ)
+    env["CONDARC"] = "./condarc"
+    check_only_offline(env, pkg_list)
+
+
+@pytest.mark.parametrize("pkg_list", [["python"], ["python", "conda"]])
+def test_env_creation_condarc_no_proxy(setup_mirror_server, pkg_list):
+    env = dict(os.environ)
+    env["CONDARC"] = "./condarc"
+    env.update(PROXY_SETTINGS)
+    check_only_offline(env, pkg_list)
 
 
 def _clean_json(fname):


### PR DESCRIPTION
This PR adds sends internet connections through a fake proxy. These should be fixed once we enable `--insecure` in conda-mirror, and probably shouldn't be merged until this is part of our workflow.